### PR TITLE
fix:多任务下载导致回调方法被覆盖

### DIFF
--- a/wkbase/src/main/java/com/chat/base/net/ud/Downloader.kt
+++ b/wkbase/src/main/java/com/chat/base/net/ud/Downloader.kt
@@ -120,7 +120,7 @@ internal class Downloader private constructor() {
         }
         taskUrls.forEachIndexed { index, taskUrl ->
             validateNeedCallback(taskUrl, onDownload, onComplete, onFail)
-            download(taskUrl, filenames[index], onDownload)
+            download(taskUrl, filenames[index], onDownload, onComplete, onFail)
         }
 
 


### PR DESCRIPTION
validateNeedCallback方法会将传入的回调存入map中。
multiDownload和multiDownload中调用的download方法都会调用validateNeedCallback方法，而download的传参onComplete, onFail都为空，这会导致回调函数被覆盖为空方法。